### PR TITLE
Fix infinite loop in chooser rendering

### DIFF
--- a/wagtailmodelchoosers/client/components/BaseChooser.js
+++ b/wagtailmodelchoosers/client/components/BaseChooser.js
@@ -105,7 +105,7 @@ class BaseChooser extends React.Component {
     // Return first non-empty field if `display` is an Array.
     if (Array.isArray(display)) {
       let i;
-      for (i = 0; i < display.length; i + 1) {
+      for (i = 0; i < display.length; i += 1) {
         const fieldName = display[i];
         if (fieldName in selectedItem && selectedItem[fieldName]) {
           return selectedItem[fieldName];


### PR DESCRIPTION
This code hangs the whole browser thread (well, it's an infinite loop) when the `display` prop is an array.

I'll see if I can release a new version of this package with this fix tomorrow.